### PR TITLE
Fix jupyter-book build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,14 +20,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r docs/requirements.txt
 
     - name: Build book
       run: |
-        jb build docs
+        jupyter-book build ./docs
 
     - name: Deploy to gh-pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v3.6.1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./docs/_build/html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+jupyter-book

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-git+https://github.com/ExecutableBookProject/cli.git@master


### PR DESCRIPTION
Closes #20, the issue was that we referenced the deprecated git repo for jupyter-book.
