### PR TITLE
hub image: update pangeo-notebook base image and jupyterlab from alpha to rc1

### DIFF
--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -106,6 +106,7 @@ RUN echo "Installing conda packages..." \
         statsmodels \
         xlrd \
         jupyter-repo2docker \
+        # IDE:
         jupyterlab-link-share \
             # ref: https://github.com/jupyterlab-contrib/jupyterlab-link-share
         jupyterlab-git \
@@ -113,10 +114,10 @@ RUN echo "Installing conda packages..." \
         jupyterlab-variableinspector \
         nbdime \
         retrolab \
-        #
-        # other
         ipydrawio \
             # a drawio IDE launchable from jupyterlab's launcher
+        #
+        # other
         compilers \
         cxx-compiler \
         cython \
@@ -136,7 +137,8 @@ RUN echo "Installing pip packages..." \
         julia \
             # To enable doing Julia stuff from Python
             # ref: https://pyjulia.readthedocs.io/en/latest/index.html
-        jupyterlab==3.1.0a12 \
+        jupyterlab==3.1.0rc1 \
+            # NOTE: This pre-release including RTC is not available in conda
             # ref: https://github.com/jupyterlab/jupyterlab
         plotly-geo \
             # NOTE: This package is not available in conda (conda-forge or

--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -5,7 +5,7 @@
 # - pangeo/pangeo-notebook tags:        https://hub.docker.com/r/pangeo/pangeo-notebook/tags
 # - pangeo-notebook conda package:      https://github.com/conda-forge/pangeo-notebook-feedstock/blob/master/recipe/meta.yaml
 #
-FROM pangeo/pangeo-notebook:2021.05.15
+FROM pangeo/pangeo-notebook:2021.07.06
 ARG DEBIAN_FRONTEND=noninteractive
 
 


### PR DESCRIPTION
- Update pangeo-notebook base image
- Bump jupyterlab==3.1.0a1 to 3.1.0rc1
