### PR TITLE
Attempt remove compilers package - will pymc3 run?

### DIFF
--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -259,7 +259,6 @@ RUN echo "Installing conda packages..." \
         # other
         websockify \
             # dependency for jupyter-remote-desktop-proxy
-        compilers \
         cxx-compiler \
         cython \
         fortran-magic \


### PR DESCRIPTION
Removing `compilers` was discussed in https://github.com/pangeo-data/jupyter-earth/issues/104#issuecomment-1048602910.

We have some issues with pymc3 that in turn will compile C(++?) things. This is an attempt to not have the `compilers` package modify our `LD_LIBRARY_PATH` in a way that breaks pymc3. The idea is that that could explain a failure that isn't around when among other things - `compilers` isn't around.

Note that removing `compilers` reverts an attempt to resolve issues with `regreg` experienced by @jonathan-taylor, as discussed on slack: https://fperezgroup.slack.com/archives/CU01JGHJ6/p1625699692293600?thread_ts=1625689725.285900&cid=CU01JGHJ6