### PR TITLE
Add github scoped creds and jupyterlab favorites

### DIFF
--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -215,7 +215,9 @@ RUN echo "Installing conda packages..." \
             # ref: https://github.com/jupyterlab-contrib/jupyterlab-link-share
         jupyterlab-git \
         jupyterlab-system-monitor \
+        jupyterlab-favorites \
         nbdime \
+        gh-scoped-creds \
         qgis \
             # We install this as an apt-get package but on startup we got errors
             # about Python integration not being available. But installing this


### PR DESCRIPTION
The most important one is the github scoped creds tool, the other is mostly convenience.

@consideRatio - this is so we can more easily push/pull from github with @yuvipanda's scoped creds tool.  I tried using it but I'm getting:

![image](https://user-images.githubusercontent.com/57394/173976308-38585631-7482-466f-ab3f-07e1eb92ae2c.png)

So perhaps there's more than installing the package to do?