### PR TITLE
hub image: Add nodejs

### DIFF
--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -222,6 +222,11 @@ RUN echo "Installing conda packages..." \
         jupyterlab-system-monitor \
         jupyterlab-favorites \
         nbdime \
+        npm \
+        nodejs \
+            # npm and nodejs are required by jupyterlab-sos (https://vatlab.github.io/sos-docs/),
+            # a JupyterLab extension that enables users to activate more than one kernel in a 
+            # single Notebook.
         gh-scoped-creds \
             # Additional setup instructions: https://github.com/yuvipanda/gh-scoped-creds#installation
             # Additional setup done: https://github.com/2i2c-org/infrastructure/commit/5a9f69b11727965fd4f07571c03eb65de5279fa4

--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -222,9 +222,8 @@ RUN echo "Installing conda packages..." \
         jupyterlab-system-monitor \
         jupyterlab-favorites \
         nbdime \
-        npm \
         nodejs \
-            # npm and nodejs are required by jupyterlab-sos (https://vatlab.github.io/sos-docs/),
+            # nodejs is required by jupyterlab-sos (https://vatlab.github.io/sos-docs/),
             # a JupyterLab extension that enables users to activate more than one kernel in a 
             # single Notebook.
         gh-scoped-creds \


### PR DESCRIPTION
Hi all - can we add nodejs to the JupyterHub image? It is required by [jupyterlab-sos](https://vatlab.github.io/sos-docs/), a JupyterLab extension that enables users to activate more than one kernel in a single Notebook.

It seems that an extension can be installed at the user level, so we only need all its dependencies ready in the JupyterHub image? Feel free to edit this PR or chat more about this if I am wrong. 

I am also okay if we can install that extension directly (the name is jupyterlab-sos using conda), but there is a conflict between this tool and the cell toolbar because their GUIs overlap each other.