### PR TITLE
hub image: install cuda-compat apt package

### DIFF
--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -258,6 +258,13 @@ RUN echo "Installing conda packages..." \
         syncthing \
             # ref: https://anaconda.org/conda-forge/syncthing
             # We also install jupyter-syncthing-proxy from pip.
+        #
+        # gpu related
+        cuda-compat \
+            # This is installed in an attempt to resolve a bug caused by the
+            # limitation of only having nvidia driver 470 and its associated
+            # cuda 11.4 driver version in the amazon machine image (AMI) we get.
+            #
  && echo "Installing conda packages complete!"
 
 


### PR DESCRIPTION
I look to resolve a bug i saw running a hello world like example.

```python
cuLinkAddData(self.handle, enums.CU_JIT_INPUT_PTX,
   2686                          ptxbuf, len(ptx), namebuf, 0, None, None)
   2687 except CudaAPIError as e:
-> 2688     raise LinkerError("%s\n%s" % (e, self.error_log))

LinkerError: [222] Call to cuLinkAddData results in UNKNOWN_CUDA_ERROR
ptxas application ptx input, line 9; fatal   : Unsupported .version 7.7; current version is '7.4'
```