### PR TITLE
hub image: downgrade code-server to address regressions (terminal)

### DIFF
--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -80,7 +80,10 @@ RUN echo "Installing apt-get packages..." \
 #       regression. See https://github.com/coder/code-server/issues/5343 and
 #       https://github.com/pangeo-data/jupyter-earth/issues/137.
 #
-RUN export VERSION=4.4.0 \
+#       We pinned code-server to version 4.3.0 because 4.4.0 introduced a
+#       regression. See https://github.com/coder/code-server/issues/5218.
+#
+RUN export VERSION=4.3.0 \
  && curl -fsSL https://code-server.dev/install.sh | sh \
  && rm -rf "${HOME}/.cache"
 


### PR DESCRIPTION
This is meant to workaround a bug about the bash terminal failing to open (https://github.com/coder/code-server/issues/5218), as described in https://github.com/pangeo-data/jupyter-earth/issues/137#issuecomment-1187457338