### PR TITLE
hub image: install firefox after xfce4

### DIFF
--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -52,7 +52,6 @@ RUN echo "Installing apt-get packages..." \
         ffmpeg \
         # jupyter-remote-desktop-proxy dependencies
         dbus-x11 \
-        firefox \
         xfce4 \
         xfce4-panel \
         xfce4-session \
@@ -73,9 +72,16 @@ RUN echo "Installing apt-get packages..." \
             # there is no great option to avoid installing it while installing
             # other xfce4 packages above it seems.
     > /dev/null \
+ && apt-get -y install \
+        firefox \
+            # For use in /desktop, it is installed after xfce4 in hope that it
+            # is configured as the default browser automatically if installed
+            # after xfce4.
+            #
  && sed -i 's/debian-sensible-browser/firefox.desktop/' /etc/xdg/xfce4/helpers.rc \
         # jupyter-remote-desktop-proxy related: firefox won't be made available
-        # via icons in the UI unless we do this.
+        # via icons in the UI unless we do this. This may not be needed, its
+        # unclear atm.
         #
     # chown $HOME to workaround that the xorg installation creates a
     # /home/jovyan/.cache directory owned by root


### PR DESCRIPTION
I'm attempting to address the input/output error reported by @whyjz when starting the default web browser as seen in xfce4 - the graphical UI for our ubuntu linux.

![image](https://user-images.githubusercontent.com/3837114/181526110-ad7990b9-b6e7-4ff9-b7d2-7d3f8752a027.png)
