### PR TITLE
Bigger update to the image: update from pymc3 to pymc (v4), default julia packages to home dir, update code-server, rely on conda instead of apt when possible

### DIFF
--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -197,36 +197,77 @@ RUN echo "Installing conda packages..." \
         # version than installed in the base image.
         #
         "jupyterlab>=3.4.3" \
+            # https://anaconda.org/conda-forge/jupyterlab
+            # https://github.com/conda-forge/jupyterlab-feedstock/blob/main/recipe/meta.yaml
         "dask-gateway>=2022.6.1" \
+            # https://anaconda.org/conda-forge/dask-gateway
+            # https://github.com/conda-forge/dask-gateway-feedstock/blob/main/recipe/meta.yaml
         #
         # visualization:
         altair \
+            # https://anaconda.org/conda-forge/altair
+            # https://github.com/conda-forge/altair-feedstock/blob/main/recipe/meta.yaml
         bqplot \
+            # https://anaconda.org/conda-forge/bqplot
+            # https://github.com/conda-forge/bqplot-feedstock/blob/main/recipe/meta.yaml
         plotly \
+            # https://anaconda.org/conda-forge/plotly
+            # https://github.com/conda-forge/plotly-feedstock/blob/main/recipe/meta.yaml
         python-kaleido \
+            # https://anaconda.org/conda-forge/python-kaleido
+            # https://github.com/conda-forge/python-kaleido-feedstock/blob/main/recipe/meta.yaml
         seaborn \
+            # https://anaconda.org/conda-forge/seaborn
+            # https://github.com/conda-forge/seaborn-feedstock/blob/main/recipe/meta.yaml
         ipycanvas \
+            # https://anaconda.org/conda-forge/ipycanvas
+            # https://github.com/conda-forge/ipycanvas-feedstock/blob/main/recipe/meta.yaml
         ipympl \
+            # https://anaconda.org/conda-forge/ipympl
+            # https://github.com/conda-forge/ipympl-feedstock/blob/main/recipe/meta.yaml
         jupyter_bokeh \
+            # https://anaconda.org/conda-forge/jupyter_bokeh
+            # https://github.com/conda-forge/jupyter_bokeh-feedstock/blob/main/recipe/meta.yaml
         jupyterlab-geojson \
+            # https://anaconda.org/conda-forge/jupyterlab-geojson
+            # https://github.com/conda-forge/jupyterlab-geojson-feedstock/blob/main/recipe/meta.yaml
         #
         # tests and formatting:
         black \
+            # https://anaconda.org/conda-forge/black
+            # https://github.com/conda-forge/black-feedstock/blob/main/recipe/meta.yaml
         flake8 \
+            # https://anaconda.org/conda-forge/flake8
+            # https://github.com/conda-forge/flake8-feedstock/blob/main/recipe/meta.yaml
         pep8 \
+            # https://anaconda.org/conda-forge/pep8
+            # https://github.com/conda-forge/pep8-feedstock/blob/main/recipe/meta.yaml
         pyflakes \
+            # https://anaconda.org/conda-forge/pyflakes
+            # https://github.com/conda-forge/pyflakes-feedstock/blob/main/recipe/meta.yaml
         pylint \
+            # https://anaconda.org/conda-forge/pylint
+            # https://github.com/conda-forge/pylint-feedstock/blob/main/recipe/meta.yaml
         pytest \
+            # https://anaconda.org/conda-forge/pytest
+            # https://github.com/conda-forge/pytest-feedstock/blob/main/recipe/meta.yaml
         pytest-cov \
+            # https://anaconda.org/conda-forge/pytest-cov
+            # https://github.com/conda-forge/pytest-cov-feedstock/blob/main/recipe/meta.yaml
         #
         # documentation:
         jupyter-book \
+            # https://anaconda.org/conda-forge/jupyter-book
+            # https://github.com/conda-forge/jupyter-book-feedstock/blob/main/recipe/meta.yaml
         jupytext \
+            # https://anaconda.org/conda-forge/jupytext
+            # https://github.com/conda-forge/jupytext-feedstock/blob/main/recipe/meta.yaml
         numpydoc \
-            # FIXME: Installing numpydoc downgrades jinja2 for some reason, see
-            #        https://github.com/conda-forge/numpydoc-feedstock/issues/22.
-            #
+            # https://anaconda.org/conda-forge/numpydoc
+            # https://github.com/conda-forge/numpydoc-feedstock/blob/main/recipe/meta.yaml
         sphinx \
+            # https://anaconda.org/conda-forge/sphinx
+            # https://github.com/conda-forge/sphinx-feedstock/blob/main/recipe/meta.yaml
         #
         # data:
         # pymc3 and dependencies start
@@ -242,35 +283,73 @@ RUN echo "Installing conda packages..." \
         mkl-service \
         # pymc3 and dependencies end
         ipydatagrid \
+            # FIXME: currently holding back ipywidgets to 7.*, see
+            #        https://github.com/bloomberg/ipydatagrid/pull/282 for a
+            #        resolution.
+            #
+            # https://anaconda.org/conda-forge/ipydatagrid
+            # https://github.com/conda-forge/ipydatagrid-feedstock/blob/main/recipe/meta.yaml
         ipyparallel \
+            # https://anaconda.org/conda-forge/ipyparallel
+            # https://github.com/conda-forge/ipyparallel-feedstock/blob/main/recipe/meta.yaml
         lxml \
+            # https://anaconda.org/conda-forge/lxml
+            # https://github.com/conda-forge/lxml-feedstock/blob/main/recipe/meta.yaml
         pyhdf \
+            # https://anaconda.org/conda-forge/pyhdf
+            # https://github.com/conda-forge/pyhdf-feedstock/blob/main/recipe/meta.yaml
         vaex \
+            # https://anaconda.org/conda-forge/vaex
+            # https://github.com/conda-forge/vaex-feedstock/blob/main/recipe/meta.yaml
         mhealpy \
+            # https://anaconda.org/conda-forge/mhealpy
+            # https://github.com/conda-forge/mhealpy-feedstock/blob/main/recipe/meta.yaml
         pytables \
+            # https://anaconda.org/conda-forge/pytables
+            # https://github.com/conda-forge/pytables-feedstock/blob/main/recipe/meta.yaml
         statsmodels \
+            # https://anaconda.org/conda-forge/statsmodels
+            # https://github.com/conda-forge/statsmodels-feedstock/blob/main/recipe/meta.yaml
         xlrd \
+            # https://anaconda.org/conda-forge/xlrd
+            # https://github.com/conda-forge/xlrd-feedstock/blob/main/recipe/meta.yaml
         jupyter-repo2docker \
+            # https://anaconda.org/conda-forge/jupyter-repo2docker
+            # https://github.com/conda-forge/jupyter-repo2docker-feedstock/blob/main/recipe/meta.yaml
         #
         # IDE:
         jupyter-vscode-proxy \
+            # https://anaconda.org/conda-forge/jupyter-vscode-proxy
+            # https://github.com/conda-forge/jupyter-vscode-proxy-feedstock/blob/main/recipe/meta.yaml
             # NOTE: Requires code-server to be installed.
             # https://pypi.org/project/jupyter-vscode-proxy/
         jupyterlab-link-share \
+            # https://anaconda.org/conda-forge/jupyterlab-link-share
+            # https://github.com/conda-forge/jupyterlab-link-share-feedstock/blob/main/recipe/meta.yaml
             # ref: https://github.com/jupyterlab-contrib/jupyterlab-link-share
         jupyterlab-git \
+            # https://anaconda.org/conda-forge/jupyterlab-git
+            # https://github.com/conda-forge/jupyterlab-git-feedstock/blob/main/recipe/meta.yaml
         jupyterlab-system-monitor \
-            # FIXME: Installing jupyterlab-system-monitor causes a downgrade of
-            #        jupyter-resource-usage. See
-            #        https://github.com/jtpio/jupyterlab-system-monitor/issues/93
-            #
+            # https://anaconda.org/conda-forge/jupyterlab-system-monitor
+            # https://github.com/conda-forge/jupyterlab-system-monitor-feedstock/blob/main/recipe/meta.yaml
         jupyterlab-favorites \
+            # https://anaconda.org/conda-forge/jupyterlab-favorites
+            # https://github.com/conda-forge/jupyterlab-favorites-feedstock/blob/main/recipe/meta.yaml
         nbdime \
+            # https://anaconda.org/conda-forge/nbdime
+            # https://github.com/conda-forge/nbdime-feedstock/blob/main/recipe/meta.yaml
         gh-scoped-creds \
+            # https://anaconda.org/conda-forge/gh-scoped-creds
+            # https://github.com/conda-forge/gh-scoped-creds-feedstock/blob/main/recipe/meta.yaml
+            #
             # Additional setup instructions: https://github.com/yuvipanda/gh-scoped-creds#installation
             # Additional setup done: https://github.com/2i2c-org/infrastructure/commit/5a9f69b11727965fd4f07571c03eb65de5279fa4
             # Related issue: https://github.com/pangeo-data/jupyter-earth/issues/96
         qgis \
+            # https://anaconda.org/conda-forge/qgis
+            # https://github.com/conda-forge/qgis-feedstock/blob/main/recipe/meta.yaml
+            #
             # We install this as an apt-get package but on startup we got errors
             # about Python integration not being available. But installing this
             # by itself didn't seem to give us the application. Installing both
@@ -287,23 +366,36 @@ RUN echo "Installing conda packages..." \
             #        causing a 1 GB download.
             #
         retrolab \
+            # https://anaconda.org/conda-forge/retrolab
+            # https://github.com/conda-forge/retrolab-feedstock/blob/main/recipe/meta.yaml
         ipydrawio \
             # a drawio IDE launchable from jupyterlab's launcher
+            # https://anaconda.org/conda-forge/ipydrawio
+            # https://github.com/conda-forge/ipydrawio-feedstock/blob/main/recipe/meta.yaml
         cxx-compiler \
+            # https://anaconda.org/conda-forge/cxx-compiler
         cython \
         fortran-magic \
+            # https://anaconda.org/conda-forge/fortran-magic
+            # https://github.com/conda-forge/fortran-magic-feedstock/blob/main/recipe/meta.yaml
         google-cloud-sdk \
+            # https://anaconda.org/conda-forge/google-cloud-sdk
+            # https://github.com/conda-forge/google-cloud-sdk-feedstock/blob/main/recipe/meta.yaml
         sympy \
+            # https://anaconda.org/conda-forge/sympy
+            # https://github.com/conda-forge/sympy-feedstock/blob/main/recipe/meta.yaml
         # Storage related
         #
         syncthing \
-            # ref: https://anaconda.org/conda-forge/syncthing
+            # https://anaconda.org/conda-forge/syncthing
             # We also install jupyter-syncthing-proxy from pip.
         #
-        # /desktop part 4: websocify and firefox
+        # /desktop part 4: websockify and firefox
         websockify \
+            # https://anaconda.org/conda-forge/websockify
             # optional performance benefit for jupyter-remote-desktop-proxy
         firefox \
+            # https://anaconda.org/conda-forge/firefox
             # optional good to have for use with jupyter-remote-desktop-proxy,
             # note that we also set it as a default in a command below.
             #

--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -367,9 +367,6 @@ RUN echo "Installing conda packages..." \
             # a drawio IDE launchable from jupyterlab's launcher
             # https://anaconda.org/conda-forge/ipydrawio
             # https://github.com/conda-forge/ipydrawio-feedstock/blob/main/recipe/meta.yaml
-        cxx-compiler \
-            # https://anaconda.org/conda-forge/cxx-compiler
-            # https://github.com/conda-forge/compilers-feedstock/blob/main/recipe/meta.yaml
         cython \
         fortran-magic \
             # https://anaconda.org/conda-forge/fortran-magic

--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -142,10 +142,10 @@ RUN wget -q "https://sourceforge.net/projects/turbovnc/files/${TURBOVNC_VERSION}
 #
 # Latest Julia version at https://julialang.org/downloads/
 #
-ENV JULIA_VERSION 1.8.1
-ENV JULIA_PATH /srv/julia
-ENV JULIA_DEPOT_PATH ${JULIA_PATH}/pkg
-ENV PATH $PATH:${JULIA_PATH}/bin
+ARG JULIA_VERSION=1.8.1
+ARG JULIA_PATH=/srv/julia
+ENV JULIA_DEPOT_PATH=${JULIA_PATH}/pkg
+ENV PATH=$PATH:${JULIA_PATH}/bin
 RUN mkdir -p ${JULIA_PATH} \
  && curl -sSL "https://julialang-s3.julialang.org/bin/linux/x64/${JULIA_VERSION%[.-]*}/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" \
   | tar -xz -C ${JULIA_PATH} --strip-components 1 \
@@ -184,6 +184,10 @@ RUN curl -L https://nixos.org/nix/install | sh
 RUN export JUPYTER_DATA_DIR="$NB_PYTHON_PREFIX/share/jupyter" \
  && julia --eval 'using Pkg; Pkg.add("IJulia"); using IJulia; installkernel("Julia");' \
  && julia --eval 'using Pkg; Pkg.instantiate(); Pkg.resolve(); pkg"precompile"'
+# Make additional julia packages be installed in the home folder while retaining
+# access to julia packages installed outside the home folder as well.
+#
+ENV JULIA_DEPOT_PATH=$HOME/.julia/pkg:$JULIA_DEPOT_PATH
 
 # We only need to install packages not listed in this file already:
 # https://github.com/pangeo-data/pangeo-docker-images/blob/master/pytorch-notebook/packages.txt

--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -63,10 +63,6 @@ RUN echo "Installing apt-get packages..." \
         # qgis
             gnupg \
             software-properties-common \
-        # pymc3-theano relies on compiling some C++ code, this may be relevant
-        # to help that compilation succeed. See this issue for details:
-        # https://github.com/pangeo-data/jupyter-earth/issues/104#issuecomment-1027210956
-        libc-dev \
     > /dev/null \
  && apt-get -y remove \
         xfce4-screensaver \
@@ -270,18 +266,13 @@ RUN echo "Installing conda packages..." \
             # https://github.com/conda-forge/sphinx-feedstock/blob/main/recipe/meta.yaml
         #
         # data:
-        # pymc3 and dependencies start
-        # - installation instructions found at: https://github.com/pymc-devs/pymc/wiki/Installation-Guide-(Linux)
-        # - installed for Abby and Facu following a slack discussion
-        #
-        # NOTE: Installing this below will make us downgrade scipy and numpy
-        #       etc.
-        #
-        pymc3 \
-        theano-pymc \
-        mkl \
-        mkl-service \
-        # pymc3 and dependencies end
+        pymc \
+            # Installed for Abby and Facu following a slack discussion, related:
+            # - https://github.com/pangeo-data/jupyter-earth/issues/153
+            # - https://github.com/pangeo-data/jupyter-earth/issues/104
+            #
+            # https://anaconda.org/conda-forge/pymc
+            # https://github.com/conda-forge/pymc-feedstock/blob/main/recipe/meta.yaml
         ipydatagrid \
             # FIXME: currently holding back ipywidgets to 7.*, see
             #        https://github.com/bloomberg/ipydatagrid/pull/282 for a

--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -85,7 +85,7 @@ RUN sed -i 's/WebBrowser=.*/WebBrowser=firefox/' /etc/xdg/xfce4/helpers.rc
 # Install visual studio code-server
 # ref: https://github.com/cdr/code-server
 #
-RUN export VERSION=4.5.1 \
+RUN export VERSION=4.7.0 \
  && curl -fsSL https://code-server.dev/install.sh | sh \
  && rm -rf "${HOME}/.cache"
 

--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -43,8 +43,6 @@ RUN echo "Installing apt-get packages..." \
             # `zip` and `unzip` which doesn't help us decompress .rar files. See
             # https://github.com/pangeo-data/pangeo-docker-images/issues/366 for
             # an issue about installing this in the base image.
-        graphviz \
-        ffmpeg \
         # /desktop part 1: install desktop UI via apt
         #
             dbus-x11 \

--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -43,12 +43,6 @@ RUN echo "Installing apt-get packages..." \
             # `zip` and `unzip` which doesn't help us decompress .rar files. See
             # https://github.com/pangeo-data/pangeo-docker-images/issues/366 for
             # an issue about installing this in the base image.
-        # common geospatial dependencies:
-        libspatialindex-dev \
-        libgeos-dev \
-        libproj-dev \
-        proj-data \
-        proj-bin \
         graphviz \
         ffmpeg \
         # /desktop part 1: install desktop UI via apt
@@ -232,6 +226,33 @@ RUN echo "Installing conda packages..." \
             # https://anaconda.org/conda-forge/jupyterlab-geojson
             # https://github.com/conda-forge/jupyterlab-geojson-feedstock/blob/main/recipe/meta.yaml
         #
+        # common geospatial dependencies:
+        qgis \
+            # https://anaconda.org/conda-forge/qgis
+            # https://github.com/conda-forge/qgis-feedstock/blob/main/recipe/meta.yaml
+            #
+            # We install this as an apt-get package but on startup we got errors
+            # about Python integration not being available. But installing this
+            # by itself didn't seem to give us the application. Installing both
+            # though makes things work, but seem to cause an initial install
+            # followed by a downgrade as the conda-forge version isn't as well
+            # updated. It also makes the installation take ~5-10 minutes longer.
+            #
+            # FIXME: Install qgis in a way that provides us with a recent
+            #        version, a shortcut from the desktop UI, and with Python
+            #        support - without also taking 5-10 minutes more than needed
+            #        to install.
+            #
+            # FIXME: Installing qgis downgrades pytorch and lots of other files,
+            #        causing a 1 GB download. The reason is unclear.
+            #
+            # NOTE: qgis depends on libspatialindex, geos, proj, but not
+            #       proj-data. Fernando added these as apt packages initially.
+            #
+        proj-data \
+            # https://anaconda.org/conda-forge/proj-data
+            # https://github.com/conda-forge/proj-data-feedstock/blob/main/recipe/meta.yaml
+        #
         # tests and formatting:
         black \
             # https://anaconda.org/conda-forge/black
@@ -341,25 +362,6 @@ RUN echo "Installing conda packages..." \
             # Additional setup instructions: https://github.com/yuvipanda/gh-scoped-creds#installation
             # Additional setup done: https://github.com/2i2c-org/infrastructure/commit/5a9f69b11727965fd4f07571c03eb65de5279fa4
             # Related issue: https://github.com/pangeo-data/jupyter-earth/issues/96
-        qgis \
-            # https://anaconda.org/conda-forge/qgis
-            # https://github.com/conda-forge/qgis-feedstock/blob/main/recipe/meta.yaml
-            #
-            # We install this as an apt-get package but on startup we got errors
-            # about Python integration not being available. But installing this
-            # by itself didn't seem to give us the application. Installing both
-            # though makes things work, but seem to cause an initial install
-            # followed by a downgrade as the conda-forge version isn't as well
-            # updated. It also makes the installation take ~5-10 minutes longer.
-            #
-            # FIXME: Install qgis in a way that provides us with a recent
-            #        version, a shortcut from the desktop UI, and with Python
-            #        support - without also taking 5-10 minutes more than needed
-            #        to install.
-            #
-            # FIXME: Installing qgis downgrades pytorch and lots of other files,
-            #        causing a 1 GB download.
-            #
         retrolab \
             # https://anaconda.org/conda-forge/retrolab
             # https://github.com/conda-forge/retrolab-feedstock/blob/main/recipe/meta.yaml
@@ -369,6 +371,7 @@ RUN echo "Installing conda packages..." \
             # https://github.com/conda-forge/ipydrawio-feedstock/blob/main/recipe/meta.yaml
         cxx-compiler \
             # https://anaconda.org/conda-forge/cxx-compiler
+            # https://github.com/conda-forge/compilers-feedstock/blob/main/recipe/meta.yaml
         cython \
         fortran-magic \
             # https://anaconda.org/conda-forge/fortran-magic


### PR DESCRIPTION
- Closes #153 
- Reduces the image size quite a bit I hope, which reduce the startup time for users the hub with a bit