### PR TITLE
Pin base image to a specific version

### DIFF
--- a/hub.jupytearth.org-image/Dockerfile
+++ b/hub.jupytearth.org-image/Dockerfile
@@ -5,7 +5,7 @@
 # - pangeo/pytorch-notebook tags:       https://hub.docker.com/r/pangeo/pytorch-notebook/tags
 # - pytorch-notebook conda package:     https://github.com/conda-forge/pytorch-notebook-feedstock/blob/master/recipe/meta.yaml
 #
-FROM pangeo/pytorch-notebook:master
+FROM pangeo/pytorch-notebook:2023.02.16
 
 # While NB_GID is often defined in these jupyter images, it isn't for
 # pangeo/base-image and derivative images. Let's define it here so copy pasting


### PR DESCRIPTION
The current pin (to `master`) meant that addressing *any* requested change will immediately pull in a lot of possibly unrelated changes - 6 months worth maybe!

This image was last fully built on Feb 16, and turns out there's a pytorch-notebook pin for that date. So this pins us there, so we can make upgrades more intentionally.

Ref https://github.com/2i2c-org/infrastructure/issues/2596, as the issue that
triggered this.